### PR TITLE
Refactor/merge workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 account.coldwire
 *.swp
+TODO.md

--- a/core/constants.py
+++ b/core/constants.py
@@ -5,10 +5,16 @@ APP_NAME      = "Coldwire"
 # network defaults
 LONGPOLL_MIN  = 5       # seconds
 LONGPOLL_MAX  = 30      # seconds
-API_TIMEOUT   = 10      # seconds
 
 # crypto parameters
-ARGON2_MEMORY = 256 * 1024   # KB
-ARGON2_ITERS  = 3
-KDF_LEN       = 32           # bytes
+AES_GCM_NONCE_LEN = 12  # bytes
 
+OTP_PADDING_LENGTH = 2      # bytes
+OTP_PADDING_LIMIT  = 1024   # bytes 
+
+
+ARGON2_MEMORY     = 256 * 1024   # KB
+ARGON2_ITERS      = 3
+ARGON2_OUTPUT_LEN = 32           # bytes
+ARGON2_SALT_LEN   = 32           # bytes
+ARGON2_LANES      = 4

--- a/core/crypto.py
+++ b/core/crypto.py
@@ -1,7 +1,6 @@
+from core.constants import *
 import oqs
 import secrets
-
-OTP_PADDING_LENGTH = 2
 
 def create_signature(algorithm: str, message: bytes, private_key: bytes) -> bytes:
     with oqs.Signature(algorithm, secret_key=private_key) as signer:
@@ -36,8 +35,7 @@ def otp_encrypt_with_padding(plaintext: bytes, key: bytes, padding_limit: int) -
 
     """
 
-    # Here we make an assumption that the padding_limit will never exceed 65535 bytes
-    if padding_limit > 65535:
+    if padding_limit > ((2 ** (8 * OTP_PADDING_LENGTH)) - 1):
         raise ValueError("Padding too large")
 
     # NOTE: If padding_limit is 0, the plaintext_paddding_bytes would also be 0

--- a/core/trad_crypto.py
+++ b/core/trad_crypto.py
@@ -1,5 +1,6 @@
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.argon2 import Argon2id
+from core.constants import *
 import hashlib
 import secrets 
 
@@ -8,7 +9,7 @@ def sha3_512(b: bytes) -> bytes:
     h.update(b)
     return h.digest()
 
-def derive_key_argon2id(password: bytes, salt: bytes = None, salt_length: int = 32, output_length: int = 32) -> tuple[bytes, bytes]:
+def derive_key_argon2id(password: bytes, salt: bytes = None, salt_length: int = ARGON2_SALT_LEN, output_length: int = ARGON2_OUTPUT_LEN) -> tuple[bytes, bytes]:
     if salt is None:
         salt = secrets.token_bytes(salt_length)
 
@@ -24,10 +25,8 @@ def derive_key_argon2id(password: bytes, salt: bytes = None, salt_length: int = 
 
 
 def encrypt_aes_gcm(key: bytes, plaintext: bytes):
-    nonce = secrets.token_bytes(12)  # GCM standard nonce size
-
+    nonce = secrets.token_bytes(AES_GCM_NONCE_LEN)  
     aes_gcm = AESGCM(key)
-
     ciphertext = aes_gcm.encrypt(nonce, plaintext, None)
 
     return nonce, ciphertext

--- a/logic/background_worker.py
+++ b/logic/background_worker.py
@@ -2,8 +2,9 @@ from core.requests import http_request
 from logic.storage import save_account_data
 from logic.contacts import save_contact
 from logic.get_user import get_target_lt_public_key
-from logic.pfs import pfs_data_handler
 from logic.smp import smp_unanswered_questions, smp_data_handler
+from logic.pfs import pfs_data_handler
+from logic.message import messages_data_handler
 from core.constants import *
 from core.crypto import random_number_range
 from core.trad_crypto import derive_key_argon2id, sha3_512

--- a/logic/background_worker.py
+++ b/logic/background_worker.py
@@ -56,7 +56,7 @@ def background_worker(user_data, user_data_lock, ui_queue, stop_flag):
                 pfs_data_handler(user_data, user_data_lock, user_data_copied, ui_queue, message)
 
             elif message["data_type"] == "message":
-                pass
+                messages_data_handler(user_data, user_data_lock, user_data_copied, ui_queue, message)
 
             else:
                 logger.error(

--- a/logic/background_worker.py
+++ b/logic/background_worker.py
@@ -1,0 +1,65 @@
+from core.requests import http_request
+from logic.storage import save_account_data
+from logic.contacts import save_contact
+from logic.get_user import get_target_lt_public_key
+from logic.pfs import pfs_data_handler
+from logic.smp import smp_unanswered_questions, smp_data_handler
+from core.constants import *
+from core.crypto import random_number_range
+from core.trad_crypto import derive_key_argon2id, sha3_512
+from base64 import b64encode, b64decode
+import hashlib
+import secrets
+import hmac
+import time
+import copy
+import logging
+import json
+
+logger = logging.getLogger(__name__)
+
+def background_worker(user_data, user_data_lock, ui_queue, stop_flag):
+    # Incase we received a SMP question request last time right before the background worker was about to exit
+    smp_unanswered_questions(user_data, user_data_lock, ui_queue)
+
+    while not stop_flag.is_set():
+        with user_data_lock:
+            server_url = user_data["server_url"]
+            auth_token = user_data["token"]
+    
+        try:
+            # Random longpoll number to help obfsucate traffic against analysis
+            response = http_request(f"{server_url}/data/longpoll", "GET", auth_token=auth_token, longpoll=random_number_range(LONGPOLL_MIN, LONGPOLL_MAX))
+        except TimeoutError:
+            logger.debug("Data longpoll request has timed out, retrying...")
+            continue
+
+        logger.debug("SMP messages: %s", json.dumps(response, indent = 2))
+
+        for message in response["messages"]:
+            # Sanity check universal message fields
+            if (not "sender" in message) or (not message["sender"].isdigit()) or (len(message["sender"]) != 16):
+                logger.error("Impossible condition, either you have discovered a bug in Coldwire, or the server is attempting to denial-of-service you. Skipping data message with no (or malformed) sender...")
+
+                if "sender" in message:
+                    logger.debug("Impossible condition's sender is: %s", message["sender"])
+
+                continue
+
+            with user_data_lock:
+                user_data_copied = copy.deepcopy(user_data)
+
+            if message["data_type"] == "smp":
+                smp_data_handler(user_data, user_data_lock, user_data_copied, ui_queue, message)
+
+            elif message["data_type"] == "pfs":
+                pfs_data_handler(user_data, user_data_lock, user_data_copied, ui_queue, message)
+
+            elif message["data_type"] == "message":
+                pass
+
+            else:
+                logger.error(
+                        "Impossible condition, either you have discovered a bug in Coldwire, or the server is attempting to denial-of-service you. Skipping data message with unknown data type (%s)...", 
+                        message["data_type"]
+                    )

--- a/logic/contacts.py
+++ b/logic/contacts.py
@@ -28,7 +28,9 @@ def save_contact(user_data: dict, user_data_lock, contact_id: str, contact_publi
                         "private_key": None,
                         },
                     "rotation_counter": None,
-                    "rotate_at": None
+                    "rotate_at": None,
+                    "our_hash_chain": None,
+                    "contact_hash_chain": None
 
                 },
                 "message_sign_keys": {

--- a/logic/message.py
+++ b/logic/message.py
@@ -215,7 +215,7 @@ def messages_data_handler(user_data, user_data_lock, user_data_copied, ui_queue,
         return
 
 
-    logger.debug("Received a new message of type: %s", message["type"])
+    logger.debug("Received a new message of type: %s", message["msg_type"])
 
     if message["msg_type"] == "new_otp_batch":
         payload_signature  = b64decode(message["payload_signature"], validate=True)

--- a/logic/message.py
+++ b/logic/message.py
@@ -194,128 +194,104 @@ def send_message_processor(user_data, user_data_lock, contact_id: str, message: 
 
 
 
+def messages_data_handler(user_data, user_data_lock, user_data_copied, ui_queue, message):
+    contact_id = message["sender"]
 
-def messages_worker(user_data, user_data_lock, ui_queue, stop_flag):
-    while not stop_flag.is_set():
-        with user_data_lock:
-            user_data_copied = copy.deepcopy(user_data)
-
-        server_url = user_data_copied["server_url"]
-        auth_token = user_data_copied["token"]
+    if (not (contact_id in user_data_copied["contacts"])):
+        logger.warning("Contact is missing, maybe we (or they) are not synced? Not sure, but we will ignore this Message request for now")
+        logger.debug("Our contacts: %s", json.dumps(user_data_copied["contacts"], indent=2))
+        continue
 
 
-        try:
-            # Random longpoll number to help obfsucate traffic against analysis
-            response = http_request(f"{server_url}/messages/longpoll", "GET", auth_token=auth_token, longpoll=random_number_range(5, 30))
-        except TimeoutError:
+    if not user_data_copied["contacts"][contact_id]["lt_sign_key_smp"]["verified"]:
+        logger.warning("Contact long-term signing key is not verified.. it is possible that this is a MiTM attack by the server, we ignoring this Message for now.")
+        continue
+
+
+    contact_d5_public_key = user_data_copied["contacts"][contact_id]["message_sign_keys"]["contact_public_key"]
+
+    if not contact_d5_public_key:
+        logger.warning("Contact per-contact Dilithium5 public key is missing.. skipping message")
+        continue
+
+
+    logger.debug("Received a new message of type: %s", message["type"])
+
+    if message["msg_type"] == "new_otp_batch":
+        payload_signature  = b64decode(message["payload_signature"], validate=True)
+        valid_signature = verify_signature("Dilithium5", message["json_payload"].encode("utf-8"), payload_signature, contact_d5_public_key)
+        if not valid_signature:
+            logger.debug("Invalid OTP batch signature.. possible MiTM ?")
             continue
 
-        logger.debug("Messages poll: %s", json.dumps(response, indent=2))
+        json_payload = json.loads(message["json_payload"])
 
-        for message in response["messages"]:
-            with user_data_lock:
-                user_data_copied = copy.deepcopy(user_data)
+        ciphertext_blob          = b64decode(json_payload["ciphertext_blob"], validate=True)
+        replay_protection_number = int(json_payload["replay_protection_number"])
 
+        our_kyber_key = user_data_copied["contacts"][contact_id]["ephemeral_keys"]["our_keys"]["private_key"]
 
-            contact_id = message["sender"]
+        try:
+            contact_pads = decrypt_kyber_shared_secrets(ciphertext_blob, our_kyber_key)
+        except:
+            logger.debug("Failed to decrypt shared_secrets, possible MiTM?")
+            continue
 
-            if (not (contact_id in user_data_copied["contacts"])):
-                logger.warning("Contact is missing, maybe we (or they) are not synced? Not sure, but we will ignore this Message request for now")
-                logger.debug("Our contacts: %s", json.dumps(user_data_copied["contacts"], indent=2))
-                continue
+        with user_data_lock:
+            user_data["contacts"][contact_id]["contact_pads"]["pads"]                     = contact_pads
+            user_data["contacts"][contact_id]["contact_pads"]["replay_protection_number"] = replay_protection_number
 
+        logger.info("Saved contact (%s) new batch of One-Time-Pads", contact_id)
 
-            if not user_data_copied["contacts"][contact_id]["lt_sign_key_smp"]["verified"]:
-                logger.warning("Contact long-term signing key is not verified.. it is possible that this is a MiTM attack by the server, we ignoring this Message for now.")
-                continue
+        save_account_data(user_data, user_data_lock)
 
+    elif message["msg_type"] == "new_message":
+        payload_signature  = b64decode(message["payload_signature"], validate=True)
+        valid_signature = verify_signature("Dilithium5", message["json_payload"].encode("utf-8"), payload_signature, contact_d5_public_key)
+        if not valid_signature:
+            logger.debug("Invalid new message signature.. possible MiTM ?")
+            continue
 
-            contact_d5_public_key = user_data_copied["contacts"][contact_id]["message_sign_keys"]["contact_public_key"]
+        json_payload             = json.loads(message["json_payload"])
+        message_encrypted        = b64decode(json_payload["message_encrypted"], validate=True)
+        replay_protection_number = int(json_payload["replay_protection_number"])
 
-            if not contact_d5_public_key:
-                logger.warning("Contact per-contact Dilithium5 public key is missing.. skipping message")
-                continue
+        with user_data_lock:
+            contact_pads                     = user_data["contacts"][contact_id]["contact_pads"]["pads"]
+            contact_replay_protection_number = user_data["contacts"][contact_id]["contact_pads"]["replay_protection_number"]
+       
 
+        if (not contact_pads) or (len(message_encrypted) > len(contact_pads)):
+            logger.warning("Message payload is larger than our local pads for the contact, we are skipping this message..")
+            continue
 
-            logger.debug("Received a new message of type: %s", message["type"])
-
-            if message["msg_type"] == "new_otp_batch":
-                payload_signature  = b64decode(message["payload_signature"], validate=True)
-                valid_signature = verify_signature("Dilithium5", message["json_payload"].encode("utf-8"), payload_signature, contact_d5_public_key)
-                if not valid_signature:
-                    logger.debug("Invalid OTP batch signature.. possible MiTM ?")
-                    continue
-
-                json_payload = json.loads(message["json_payload"])
-
-                ciphertext_blob          = b64decode(json_payload["ciphertext_blob"], validate=True)
-                replay_protection_number = int(json_payload["replay_protection_number"])
-
-                our_kyber_key = user_data_copied["contacts"][contact_id]["ephemeral_keys"]["our_keys"]["private_key"]
-
-                try:
-                    contact_pads = decrypt_kyber_shared_secrets(ciphertext_blob, our_kyber_key)
-                except:
-                    logger.debug("Failed to decrypt shared_secrets, possible MiTM?")
-                    continue
-
-                with user_data_lock:
-                    user_data["contacts"][contact_id]["contact_pads"]["pads"]                     = contact_pads
-                    user_data["contacts"][contact_id]["contact_pads"]["replay_protection_number"] = replay_protection_number
-
-                logger.info("Saved contact (%s) new batch of One-Time-Pads", contact_id)
-
-                save_account_data(user_data, user_data_lock)
-
-            elif message["msg_type"] == "new_message":
-                payload_signature  = b64decode(message["payload_signature"], validate=True)
-                valid_signature = verify_signature("Dilithium5", message["json_payload"].encode("utf-8"), payload_signature, contact_d5_public_key)
-                if not valid_signature:
-                    logger.debug("Invalid new message signature.. possible MiTM ?")
-                    continue
-
-                json_payload             = json.loads(message["json_payload"])
-                message_encrypted        = b64decode(json_payload["message_encrypted"], validate=True)
-                replay_protection_number = int(json_payload["replay_protection_number"])
-
-                with user_data_lock:
-                    contact_pads                     = user_data["contacts"][contact_id]["contact_pads"]["pads"]
-                    contact_replay_protection_number = user_data["contacts"][contact_id]["contact_pads"]["replay_protection_number"]
-               
-
-                if (not contact_pads) or (len(message_encrypted) > len(contact_pads)):
-                    logger.warning("Message payload is larger than our local pads for the contact, we are skipping this message..")
-                    continue
-
-                if (not contact_replay_protection_number) or (replay_protection_number <= contact_replay_protection_number):
-                    logger.warning("Message replay_protection_number is equal or smaller than our saved replay_protection_number, this could be a possible replay attack, skipping this message...")
-                    continue
+        if (not contact_replay_protection_number) or (replay_protection_number <= contact_replay_protection_number):
+            logger.warning("Message replay_protection_number is equal or smaller than our saved replay_protection_number, this could be a possible replay attack, skipping this message...")
+            continue
 
 
-                message_decrypted = otp_decrypt_with_padding(message_encrypted, contact_pads[:len(message_encrypted)])
-               
-                # immediately truncate the pads
-                contact_pads = contact_pads[len(message_encrypted):] 
+        message_decrypted = otp_decrypt_with_padding(message_encrypted, contact_pads[:len(message_encrypted)])
+       
+        # immediately truncate the pads
+        contact_pads = contact_pads[len(message_encrypted):] 
 
-                # and immediately save the new pads and replay protection number
-                with user_data_lock:
-                    user_data["contacts"][contact_id]["contact_pads"]["pads"]                     = contact_pads
-                    user_data["contacts"][contact_id]["contact_pads"]["replay_protection_number"] = replay_protection_number
+        # and immediately save the new pads and replay protection number
+        with user_data_lock:
+            user_data["contacts"][contact_id]["contact_pads"]["pads"]                     = contact_pads
+            user_data["contacts"][contact_id]["contact_pads"]["replay_protection_number"] = replay_protection_number
 
-                save_account_data(user_data, user_data_lock)
+        save_account_data(user_data, user_data_lock)
 
-                logger.info("Truncated pads and updated replay_protect_number for contact (%s)", contact_id)
+        logger.info("Truncated pads and updated replay_protect_number for contact (%s)", contact_id)
 
-                try:
-                    message_decoded = message_decrypted.decode("utf-8")
-                except:
-                    logger.error("Failed to decode UTF-8 message, we will not be showing this message.")
-                    continue
+        try:
+            message_decoded = message_decrypted.decode("utf-8")
+        except:
+            logger.error("Failed to decode UTF-8 message, we will not be showing this message.")
+            continue
 
-                ui_queue.put({
-                    "type": "new_message",
-                    "contact_id": contact_id,
-                    "message": message_decoded
-                })
-                
-            
+        ui_queue.put({
+            "type": "new_message",
+            "contact_id": contact_id,
+            "message": message_decoded
+        })

--- a/logic/pfs.py
+++ b/logic/pfs.py
@@ -4,7 +4,6 @@ from logic.get_user import get_target_lt_public_key
 from core.crypto import generate_kem_keys, verify_signature, create_signature, generate_sign_keys, random_number_range
 from core.trad_crypto import derive_key_argon2id, sha3_512
 from base64 import b64encode, b64decode
-import hashlib
 import secrets
 import hmac
 import time
@@ -16,25 +15,41 @@ import oqs
 
 logger = logging.getLogger(__name__)
 
-
+# TODO: Add hashchain replay protection
 def rotate_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue) -> None:
     with user_data_lock:
-        server_url = user_data["server_url"]
-        auth_token = user_data["token"]
+        user_data_copied = copy.deepcopy(user_data)
+  
+    server_url = user_data_copied["server_url"]
+    auth_token = user_data_copied["token"]
 
-        d5_private_key = user_data["contacts"][contact_id]["message_sign_keys"]["our_keys"]["private_key"]
+    d5_private_key = user_data_copied["contacts"][contact_id]["message_sign_keys"]["our_keys"]["private_key"]
+
+
+    # Check if we already have a hash chain for ourselves
+    if not user_data_copied["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"]:
+        with user_data_lock:
+            # Set up the hash chain's initial seed
+            user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] = secrets.token_bytes(64)
+            
+            our_hash_chain = user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] 
+    else:
+        our_hash_chain = user_data_copied["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] 
+        # We continue the hash chain
+        our_hash_chain = sha3_512(our_hash_chain)
+
 
     # Generate new Kyber1024 keys for us and send them to contact
     kyber_private_key, kyber_public_key = generate_kem_keys()
 
-    # Sign it with our per-contact long-term private key
-    kyber_key_signature = create_signature("Dilithium5", kyber_public_key, d5_private_key)
+    # Sign them with our per-contact long-term private key
+    kyber_key_hashchain_signature = create_signature("Dilithium5", our_hash_chain + kyber_public_key, d5_private_key)
     
     payload = {
-            "kyber_public_key": b64encode(kyber_public_key).decode(),
-            "kyber_signature" : b64encode(kyber_key_signature).decode(),
-            "recipient"       : contact_id,
-            "pfs_type"        : "rotate"
+            "kyber_publickey_hashchain": b64encode(our_hash_chain + kyber_public_key).decode(),
+            "kyber_hashchain_signature": b64encode(kyber_key_hashchain_signature).decode(),
+            "recipient"                : contact_id,
+            "pfs_type"                 : "rotate"
         }
 
 
@@ -50,6 +65,8 @@ def rotate_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue) -> No
         user_data["contacts"][contact_id]["ephemeral_keys"]["our_keys"]["private_key"] = kyber_private_key
         user_data["contacts"][contact_id]["ephemeral_keys"]["our_keys"]["public_key"] = kyber_public_key
 
+        user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] = our_hash_chain
+
         rotation_counter = user_data["contacts"][contact_id]["ephemeral_keys"]["rotation_counter"]
         rotate_at        = user_data["contacts"][contact_id]["ephemeral_keys"]["rotate_at"]
         if rotation_counter == rotate_at:
@@ -59,12 +76,7 @@ def rotate_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue) -> No
 
 
 
-
-
-
-
 # TODO: Some of code here is duplicated in rotate_ephemeral_keys function, maybe clean it up?
-
 def send_new_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue) -> None:
     with user_data_lock:
         user_data_copied = copy.deepcopy(user_data)
@@ -89,17 +101,30 @@ def send_new_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue) -> 
         d5_public_key  = user_data["contacts"][contact_id]["message_sign_keys"]["our_keys"]["public_key"]
 
     
+    # Check if we already have a hash chain for ourselves
+    if not user_data_copied["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"]:
+        with user_data_lock:
+            # Set up the hash chain's initial seed
+            user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] = secrets.token_bytes(64)
+            
+            our_hash_chain = user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] 
+    else:
+        our_hash_chain = user_data_copied["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] 
+        # We continue the hash chain
+        our_hash_chain = sha3_512(our_hash_chain)
+
     # Generate new Kyber1024 keys for us and send them to contact
     kyber_private_key, kyber_public_key = generate_kem_keys()
 
-    # Sign it with our per-contact long-term private key
-    kyber_key_signature = create_signature("Dilithium5", kyber_public_key, d5_private_key)
+
+    # Sign them with our per-contact long-term private key
+    kyber_key_hashchain_signature = create_signature("Dilithium5", our_hash_chain + kyber_public_key, d5_private_key)
     
     payload = {
-            "kyber_public_key": b64encode(kyber_public_key).decode(),
-            "kyber_signature" : b64encode(kyber_key_signature).decode(),
-            "recipient"       : contact_id,
-            "pfs_type"        : "init"
+            "kyber_publickey_hashchain": b64encode(our_hash_chain + kyber_public_key).decode(),
+            "kyber_hashchain_signature": b64encode(kyber_key_hashchain_signature).decode(),
+            "recipient"                : contact_id,
+            "pfs_type"                 : "init"
         }
 
 
@@ -107,6 +132,8 @@ def send_new_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue) -> 
         # We avoid sending d5 public key and signature, because if we have the contact public_key
         # it means he has received our d5 public_key already
         # This is important step to avoid over-using our long-term key, which might weaken its security
+        #
+        # TODO: Add replay protection here too, but just hash contact public-key and append it to start of d5_public_key
 
         d5_key_signature = create_signature("Dilithium5", d5_public_key, lt_sign_private_key)
         payload["d5_public_key"] = b64encode(d5_public_key).decode()
@@ -124,7 +151,10 @@ def send_new_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue) -> 
         user_data["contacts"][contact_id]["ephemeral_keys"]["our_keys"]["private_key"] = kyber_private_key
         user_data["contacts"][contact_id]["ephemeral_keys"]["our_keys"]["public_key"] = kyber_public_key
 
-        # Set rotation counters to rotate every 2 pads sent
+        user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] = our_hash_chain
+
+        # Set rotation counters to rotate every 2 pad batches sent
+        # TODO: Maybe rotate on every batch instead? and rework the counters, like we don't even need counters if we rotate on every batch sent.
         user_data["contacts"][contact_id]["ephemeral_keys"]["rotation_counter"] = 0
         user_data["contacts"][contact_id]["ephemeral_keys"]["rotate_at"] = 2
 
@@ -132,128 +162,142 @@ def send_new_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue) -> 
         user_data["tmp"]["ephemeral_key_send_lock"][contact_id] = True
 
 
+def pfs_data_handler(user_data, user_data_lock, user_data_copied, ui_queue, message) -> None:
+    contact_id = message["sender"]
 
-def perfect_forward_secrecy_worker(user_data, user_data_lock, ui_queue, stop_flag):
-    while not stop_flag.is_set():
+    if (not (contact_id in user_data_copied["contacts"])):
+        logger.error("Contact is missing, maybe we (or they) are not synced? Not sure, but we will ignore this PFS request for now")
+        logger.debug("Our saved contacts: %s", json.dumps(user_data_copied["contacts"], indent=2))
+        return
+
+    # Contact's main long-term public signing key
+    contact_lt_public_key = user_data_copied["contacts"][contact_id]["lt_sign_public_key"]
+
+    if not contact_lt_public_key:
+        logger.error("Contact long-term signing key is missing... 0 clue how we reached here, but we aint continuing..")
+        return 
+
+    if not user_data_copied["contacts"][contact_id]["lt_sign_key_smp"]["verified"]:
+        logger.error("Contact long-term signing key is not verified! it is possible that this is a MiTM attack by the server, we ignoring this PFS for now.")
+        return
+
+    if message["pfs_type"] == "rotate":
+        d5_public_key = user_data_copied["contacts"][contact_id]["message_sign_keys"]["contact_public_key"]
+
+        contact_kyber_hashchain_signature = b64decode(message["kyber_hashchain_signature"], validate=True)
+        contact_kyber_publickey_hashchain = b64decode(message["kyber_publickey_hashchain"], validate=True)
+
+        valid_signature = verify_signature("Dilithium5", contact_kyber_publickey_hashchain, contact_kyber_hashchain_signature, d5_public_key)
+        if not valid_signature:
+            logger.error("Invalid ephemeral kyber public-key + hashchain signature! possible MiTM ?")
+            return
+
+
+        contact_kyber_public_key = contact_kyber_publickey_hashchain[64:]
+        contact_hash_chain       = contact_kyber_publickey_hashchain[:64]
+        contact_last_hash_chain  = user_data_copied["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"]
+        if not contact_last_hash_chain:
+            logger.error("Contact does not have a saved hash chain despite asking to rotate ephemeral keys! You may have discovered a bug.")
+            return
+        else:
+            contact_last_hash_chain = sha3_512(contact_last_hash_chain)
+
+            if contact_last_hash_chain != contact_hash_chain:
+                logger.error("Contact hash chain does not match our computed hash chain, we are skipping this PFS message...")
+                return
+
         with user_data_lock:
-            user_data_copied = copy.deepcopy(user_data)
+            user_data["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"] = contact_hash_chain
+            user_data["contacts"][contact_id]["ephemeral_keys"]["contact_public_key"] = contact_kyber_public_key
 
-        server_url = user_data_copied["server_url"]
-        auth_token = user_data_copied["token"]
+        logger.info("Contact (%s) has rotated his ephemeral kyber keys")
 
+    elif message["pfs_type"] == "init":
+        if (not user_data_copied["contacts"][contact_id]["message_sign_keys"]["contact_public_key"]) and ((not ("d5_public_key" in message)) or not ("d5_signature" in message)):
+            logger.error("Contact did not send the per-contact Dilithium5 public key or its signature despite us not having a copy... skipping PFS message")
+            return
 
-        try:
-            # Random longpoll number to help obfsucate traffic against analysis
-            response = http_request(f"{server_url}/pfs/longpoll", "GET", auth_token=auth_token, longpoll=random_number_range(5, 30))
-        except TimeoutError:
-            continue
+        # Check if contact wants to send or rotate long-term per-contact signing keys
+        if ("d5_public_key" in message) and ("d5_signature" in message):
+            d5_public_key = b64decode(message["d5_public_key"], validate=True)
+            d5_signature  = b64decode(message["d5_signature"], validate=True)
+            valid_signature = verify_signature("Dilithium5", d5_public_key, d5_signature, contact_lt_public_key)
+            if not valid_signature:
+                logger.error("Invalid per-contact Dilithium5 public-key signature! possible MiTM ?")
+                return
 
-        logger.debug("PFS messages: %s", json.dumps(response, indent=2))
-
-        for message in response["messages"]:
+            # This is so it allows multiple key rotation within the same session without restarting the app
             with user_data_lock:
-                user_data_copied = copy.deepcopy(user_data)
+                if contact_id in user_data["tmp"]["ephemeral_key_send_lock"]:
+                    del user_data["tmp"]["ephemeral_key_send_lock"][contact_id]
+
+        else:
+            d5_public_key = user_data_copied["contacts"][contact_id]["message_sign_keys"]["contact_public_key"]
+
+        contact_kyber_hashchain_signature = b64decode(message["kyber_hashchain_signature"], validate=True)
+        contact_kyber_publickey_hashchain = b64decode(message["kyber_publickey_hashchain"], validate=True)
+
+        valid_signature = verify_signature("Dilithium5", contact_kyber_publickey_hashchain, contact_kyber_hashchain_signature, d5_public_key)
+        if not valid_signature:
+            logger.error("Invalid ephemeral kyber public-key + hashchain signature! possible MiTM ?")
+            return
 
 
-            contact_id = message["sender"]
+        contact_kyber_public_key = contact_kyber_publickey_hashchain[64:]
+        contact_hash_chain       = contact_kyber_publickey_hashchain[:64]
 
-            if (not (contact_id in user_data_copied["contacts"])):
-                logger.debug("Contact is missing, maybe we (or they) are not synced? Not sure, but we will ignore this PFS request for now")
-                logger.debug("Our contacts: %s", json.dumps(user_data_copied["contacts"], indent=2))
-                continue
+        # If we do not have a hashchain for the contact, we don't need to compute the chain, just save.
+        if not user_data_copied["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"]:
+            with user_data_lock:
+                user_data["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"] = contact_hash_chain
+        
+        else:
+            contact_last_hash_chain = user_data_copied["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"]
+            contact_last_hash_chain = sha3_512(contact_last_hash_chain)
 
-            contact_lt_public_key = user_data_copied["contacts"][contact_id]["lt_sign_public_key"]
+            if contact_last_hash_chain != contact_hash_chain:
+                logger.error("Contact hash chain does not match our computed hash chain, we are skipping this PFS message...")
+                return
 
-            if not contact_lt_public_key:
-                logger.debug("Contact long-term signing key is missing... 0 clue how we reached here, but we aint continuing..")
-                continue
-
-            if not user_data_copied["contacts"][contact_id]["lt_sign_key_smp"]["verified"]:
-                logger.debug("Contact long-term signing key is not verified.. it is possible that this is a MiTM attack by the server, we ignoring this PFS for now.")
-                continue
-
-
-            if message["pfs_type"] == "rotate":
-                d5_public_key = user_data_copied["contacts"][contact_id]["message_sign_keys"]["contact_public_key"]
-                contact_kyber_key_signature = b64decode(message["kyber_signature"], validate=True)
-                contact_kyber_public_key    = b64decode(message["kyber_public_key"], validate=True)
-
-                valid_signature = verify_signature("Dilithium5", contact_kyber_public_key, contact_kyber_key_signature, d5_public_key)
-                if not valid_signature:
-                    logger.debug("Invalid ephemeral kyber public-key signature.. possible MiTM ?")
-                    continue
+        with user_data_lock:
+            user_data["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"] = contact_hash_chain
+            user_data["contacts"][contact_id]["ephemeral_keys"]["contact_public_key"] = contact_kyber_public_key
 
 
+        # TODO: Investigate possible infinite loopback
+        # Details: What if contact_id wasn't in tmp (i.e. user closed the app and re-opened later )
+        # then we re-send the keys ?! And not only that, if the contact also offline, and he receive it
+        # he will also resend keys
+        # and if we are offline, we also resend keys.
+        # so on and so fourth
+        # Maybe ephemeral_key_send_lock need to be in the contact info, not in tmp ?
+
+        if contact_id in user_data_copied["tmp"]["ephemeral_key_send_lock"]:
+            logger.debug("We don't have to re-send keys, as we already have sent them, time to inform user of success :)")
+
+            # Incase this was auto-fired by SMP's step 4, we don't want to give the user another popup
+            if not (contact_id in user_data_copied["tmp"]["pfs_do_not_inform"]):
+                logger.info("Successfully initialized ephemeral keys with contacts (%s)", contact_id)
+                ui_queue.put({"type": "showinfo", "title": "Success", "message": f"Successfully initialized ephemeral keys with contact ({contact_id[:32]})"})
+            else:
+                logger.info("Not informing the user of successful ephemeral keys initialization because step was likely automatically fired")
+                
+                # We delete incase user end up rotating per-contact long-term keys within the same session
                 with user_data_lock:
-                    user_data["contacts"][contact_id]["ephemeral_keys"]["contact_public_key"] = contact_kyber_public_key
-     
-                save_account_data(user_data, user_data_lock)
+                    del user_data["tmp"]["pfs_do_not_inform"][contact_id]
+        else:
+            # Send our ephemeral keys back to the contact
+            send_new_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue)
 
-                logger.info("Contact (%s) has rotated his ephemeral kyber keys")
+        with user_data_lock:
+            user_data["contacts"][contact_id]["message_sign_keys"]["contact_public_key"] = d5_public_key
 
-            elif message["pfs_type"] == "init":
+            if contact_id in user_data["tmp"]["ephemeral_key_send_lock"]:
+                del user_data["tmp"]["ephemeral_key_send_lock"][contact_id]
+    
+    else:
+        logger.error("Received PFS message with unknown type (%s), skipping it...", message["pfs_type"])
+        return
 
-                if (not user_data_copied["contacts"][contact_id]["message_sign_keys"]["contact_public_key"]) and ((not ("d5_public_key" in message)) or not ("d5_signature" in message)):
-                    logger.debug("Contact did not send the per-contact Dilithium5 public key or its signature.. skipping PFS message")
-                    continue
-
-           
-
-                # Check if contact wants to send or rotate long-term per-contact signing keys
-                if ("d5_public_key" in message) and ("d5_signature" in message):
-                    d5_public_key = b64decode(message["d5_public_key"], validate=True)
-                    d5_signature  = b64decode(message["d5_signature"], validate=True)
-                    valid_signature = verify_signature("Dilithium5", d5_public_key, d5_signature, contact_lt_public_key)
-                    if not valid_signature:
-                        logger.debug("Invalid per-contact Dilithium5 public-key signature.. possible MiTM ?")
-                        continue
-
-                    # This is so it allows multiple key rotation within the same session without restarting the app
-                    with user_data_lock:
-                        if contact_id in user_data["tmp"]["ephemeral_key_send_lock"]:
-                            del user_data["tmp"]["ephemeral_key_send_lock"][contact_id]
-
-                else:
-                    d5_public_key = user_data_copied["contacts"][contact_id]["message_sign_keys"]["contact_public_key"]
-
-
-
-                contact_kyber_key_signature = b64decode(message["kyber_signature"], validate=True)
-                contact_kyber_public_key    = b64decode(message["kyber_public_key"], validate=True)
-
-                valid_signature = verify_signature("Dilithium5", contact_kyber_public_key, contact_kyber_key_signature, d5_public_key)
-                if not valid_signature:
-                    logger.debug("Invalid ephemeral kyber public-key signature.. possible MiTM ?")
-                    continue
-
-
-                with user_data_lock:
-                    user_data["contacts"][contact_id]["ephemeral_keys"]["contact_public_key"] = contact_kyber_public_key
-     
-
-
-                if contact_id in user_data_copied["tmp"]["ephemeral_key_send_lock"]:
-                    logger.debug("We don't have to re-send keys, as we already have sent them, time to inform user of success :)")
-
-                    # Incase this was autofired by SMP's step 4, we don't want to give the user another popup
-                    if not (contact_id in user_data_copied["tmp"]["pfs_do_not_inform"]):
-                        ui_queue.put({"type": "showinfo", "title": "Success", "message": f"Successfully initialized ephemeral keys with contact ({contact_id[:32]})"})
-                    else:
-                        logger.info("Not informing the user of successful ephemeral keys initialization because step was likely automatically fired")
-                        
-                        # We delete incase user end up rotating keys within the same session
-                        with user_data_lock:
-                            del user_data["tmp"]["pfs_do_not_inform"][contact_id]
-                else:
-                    # Send and or rotate our ephemeral keys as well
-                    send_new_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue)
-
-                with user_data_lock:
-                    user_data["contacts"][contact_id]["message_sign_keys"]["contact_public_key"] = d5_public_key
-
-                    if contact_id in user_data["tmp"]["ephemeral_key_send_lock"]:
-                        del user_data["tmp"]["ephemeral_key_send_lock"][contact_id]
-
-
-                save_account_data(user_data, user_data_lock)
+    save_account_data(user_data, user_data_lock)
 

--- a/logic/smp.py
+++ b/logic/smp.py
@@ -391,5 +391,3 @@ def smp_data_handler(user_data, user_data_lock, user_data_copied, ui_queue, mess
 
 
 
-
-    ""

--- a/logic/storage.py
+++ b/logic/storage.py
@@ -80,6 +80,17 @@ def load_account_data(password = None) -> dict:
         except TypeError:
             pass
 
+        try:
+            user_data["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"] = b64decode(user_data["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"], validate=True)
+        except TypeError:
+            pass
+
+        try:
+            user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] = b64decode(user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"], validate=True)
+        except TypeError:
+            pass
+
+
 
     logger.debug("Loaded user_data from file (%s)", ACCOUNT_FILE_PATH)
 
@@ -135,6 +146,17 @@ def save_account_data(user_data: dict, user_data_lock, password = None) -> None:
             user_data["contacts"][contact_id]["contact_pads"]["pads"] = b64encode(user_data["contacts"][contact_id]["contact_pads"]["pads"]).decode()
         except TypeError:
             pass
+
+        try:
+            user_data["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"] = b64encode(user_data["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"]).decode()
+        except TypeError:
+            pass
+
+        try:
+            user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] = b64encode(user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"]).decode()
+        except TypeError:
+            pass
+
 
 
 

--- a/main.py
+++ b/main.py
@@ -1,12 +1,38 @@
 from ui.contact_list import ContactListWindow
 import logging
+import argparse
+import sys
 
-logging.basicConfig(
-    level=logging.DEBUG,
-    format="%(asctime)s [%(levelname)s] %(name)s:%(funcName)s:%(lineno)d - %(message)s"
+class LevelBasedFormatter(logging.Formatter):
+    FORMATS = {
+        logging.DEBUG:    "%(asctime)s [%(levelname)s] %(name)s:%(funcName)s:%(lineno)d - %(message)s",
+        logging.INFO:     "%(asctime)s [%(levelname)s] -  %(message)s",
+        logging.WARNING:  "%(asctime)s %(levelname)s] %(name)s - %(message)s",
+        logging.ERROR:    "%(asctime)s [%(levelname)s] %(name)s:%(funcName)s:%(lineno)d - %(message)s",
+        logging.CRITICAL: "%(asctime)s [%(levelname)s] %(name)s:%(funcName)s:%(lineno)d - %(message)s"
+    }
 
-)
+    def format(self, record):
+        fmt = self.FORMATS.get(record.levelno, self._fmt)
+        formatter = logging.Formatter(fmt)
+        return formatter.format(record)
+
+def setup_logging(debug: bool) -> None:
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(LevelBasedFormatter())
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG if debug else logging.INFO)
+    logger.addHandler(handler)
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Coldwire - Post-Quantum secure messenger")
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    return parser.parse_args()
+
 
 if __name__ == "__main__":
+    args = parse_args()
+    setup_logging(args.debug)
     app = ContactListWindow()
     app.mainloop()
+   


### PR DESCRIPTION
Refactored code to use 1 longpolling HTTP thread instead of previous 3 threads. This should significantly reduce network fingerprinting, and solve a lot of would-be race-conditions.
Added metadata-free replay protections for perfect-forward-secrecy ephemeral key exchange using a hash chain
Added core/constants.py for better code hygiene instead of hard-coding values
Added --debug as an option instead of default 
Fixed a lot of typos and added more code documentation