### PR TITLE
Refactor/plausible deniability

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -9,7 +9,7 @@ LONGPOLL_MAX  = 30      # seconds
 # crypto parameters
 AES_GCM_NONCE_LEN = 12  # bytes
 
-OTP_PAD_SIZE       = 10240  # bytes
+OTP_PAD_SIZE       = 11264  # bytes
 OTP_PADDING_LENGTH = 2      # bytes
 OTP_PADDING_LIMIT  = 1024   # bytes 
 

--- a/core/crypto.py
+++ b/core/crypto.py
@@ -111,7 +111,7 @@ def generate_kem_keys(algorithm: str = "Kyber1024"):
         return private_key, public_key
 
 
-def decrypt_kyber_shared_secrets(ciphertext_blob: bytes, private_key: bytes, otp_pad_size: int = 10240):
+def decrypt_kyber_shared_secrets(ciphertext_blob: bytes, private_key: bytes, otp_pad_size: int = OTP_PAD_SIZE):
     """
         Decapsulates shared_secrets of size otp_pad_size and returns the resulting shared_secrets.
         The ciphertexts_blob is expected to be a concatenated sequence of Kyber ciphertexts,
@@ -123,9 +123,10 @@ def decrypt_kyber_shared_secrets(ciphertext_blob: bytes, private_key: bytes, otp
         split the blob and decapsulate in order.
     """
 
+    cipher_size    = 1568  # Kyber1024 ciphertext size
+    
     shared_secrets = b''
-    cipher_size = 1568  # Kyber1024 ciphertext size
-    cursor = 0
+    cursor         = 0
 
     with oqs.KeyEncapsulation("Kyber1024", secret_key=private_key) as kem:
         while len(shared_secrets) < otp_pad_size:

--- a/core/crypto.py
+++ b/core/crypto.py
@@ -111,7 +111,7 @@ def generate_kem_keys(algorithm: str = "Kyber1024"):
         return private_key, public_key
 
 
-def decrypt_kyber_shared_secrets(ciphertext_blob: bytes, private_key: bytes, otp_pad_size: int = 10240, algorithm: str = "Kyber1024"):
+def decrypt_kyber_shared_secrets(ciphertext_blob: bytes, private_key: bytes, otp_pad_size: int = 10240):
     """
         Decapsulates shared_secrets of size otp_pad_size and returns the resulting shared_secrets.
         The ciphertexts_blob is expected to be a concatenated sequence of Kyber ciphertexts,
@@ -127,7 +127,7 @@ def decrypt_kyber_shared_secrets(ciphertext_blob: bytes, private_key: bytes, otp
     cipher_size = 1568  # Kyber1024 ciphertext size
     cursor = 0
 
-    with oqs.KeyEncapsulation(algorithm, secret_key=private_key) as kem:
+    with oqs.KeyEncapsulation("Kyber1024", secret_key=private_key) as kem:
         while len(shared_secrets) < otp_pad_size:
             ciphertext = ciphertext_blob[cursor:cursor + cipher_size]
 
@@ -140,7 +140,7 @@ def decrypt_kyber_shared_secrets(ciphertext_blob: bytes, private_key: bytes, otp
 
     return shared_secrets[:otp_pad_size]
 
-def generate_kyber_shared_secrets(public_key: bytes, otp_pad_size: int = OTP_PAD_SIZE, algorithm: str = "Kyber1024"):
+def generate_kyber_shared_secrets(public_key: bytes, otp_pad_size: int = OTP_PAD_SIZE):
     """
         Generates shared_secrets of size otp_pad_size and returns both the ciphertext list-
         and the generated shared_secrets.
@@ -159,7 +159,7 @@ def generate_kyber_shared_secrets(public_key: bytes, otp_pad_size: int = OTP_PAD
     shared_secrets   = b''
     ciphertexts_blob = b''
 
-    with oqs.KeyEncapsulation(algorithm) as kem:
+    with oqs.KeyEncapsulation("Kyber1024") as kem:
         while len(shared_secrets) < otp_pad_size:
             ciphertext, shared_secret = kem.encap_secret(public_key)
 
@@ -168,9 +168,6 @@ def generate_kyber_shared_secrets(public_key: bytes, otp_pad_size: int = OTP_PAD
 
     return ciphertexts_blob, shared_secrets[:otp_pad_size]
 
-
-def randomize_replay_protection_number(replay_protection_number: int) -> int:
-    return random_number_range(replay_protection_number, random_number_range(replay_protection_number + 1, replay_protection_number + random_number_range(100, 1000)))
 
 def random_number_range(a: int, b: int) -> int:
     return secrets.randbelow(b - a + 1) + a

--- a/logic/background_worker.py
+++ b/logic/background_worker.py
@@ -1,7 +1,6 @@
 from core.requests import http_request
 from logic.storage import save_account_data
 from logic.contacts import save_contact
-from logic.get_user import get_target_lt_public_key
 from logic.smp import smp_unanswered_questions, smp_data_handler
 from logic.pfs import pfs_data_handler
 from logic.message import messages_data_handler

--- a/logic/contacts.py
+++ b/logic/contacts.py
@@ -29,19 +29,21 @@ def generate_random_nickname(user_data: dict, user_data_lock, contact_id: str, n
             return nickname
 
 
-def save_contact(user_data: dict, user_data_lock, contact_id: str, contact_public_key: bytes) -> None:
+def save_contact(user_data: dict, user_data_lock, contact_id: str) -> None:
     with user_data_lock:
         if contact_id in user_data["contacts"]:
             raise ValueError("Contact already saved!")
 
-        for i, v in user_data["contacts"].items():
-            if v["lt_sign_public_key"] == contact_public_key:
-                raise ValueError("Contact long-term auth signing public-key is duplicated, and we have no idea why")
-       
         
         user_data["contacts"][contact_id] = {
                 "nickname": None,
-                "lt_sign_public_key": contact_public_key,
+                "lt_sign_keys": {
+                    "contact_public_key": None,
+                    "our_keys": {
+                            "private_key": None,
+                            "public_key": None        
+                        }
+                    },
                 "lt_sign_key_smp": {
                     "verified": False,
                     "pending_verification": False,
@@ -62,13 +64,6 @@ def save_contact(user_data: dict, user_data_lock, contact_id: str, contact_publi
                     "our_hash_chain": None,
                     "contact_hash_chain": None
 
-                },
-                "message_sign_keys": {
-                    "contact_public_key": None,
-                    "our_keys": {
-                        "private_key": None,
-                        "public_key": None        
-                    }
                 },
                 "our_pads": {
                     "replay_protection_number": None,

--- a/logic/contacts.py
+++ b/logic/contacts.py
@@ -42,8 +42,11 @@ def save_contact(user_data: dict, user_data_lock, contact_id: str) -> None:
                     "our_keys": {
                             "private_key": None,
                             "public_key": None        
-                        }
-                    },
+                        }, 
+                    "our_hash_chain": None,
+                    "contact_hash_chain": None
+
+                },
                 "lt_sign_key_smp": {
                     "verified": False,
                     "pending_verification": False,
@@ -61,16 +64,14 @@ def save_contact(user_data: dict, user_data_lock, contact_id: str) -> None:
                         },
                     "rotation_counter": None,
                     "rotate_at": None,
-                    "our_hash_chain": None,
-                    "contact_hash_chain": None
 
                 },
                 "our_pads": {
-                    "replay_protection_number": None,
+                    "hash_chain": None,
                     "pads": None
                 },
                 "contact_pads": {
-                    "replay_protection_number": None,
+                    "hash_chain": None,
                     "pads": None
                 },
             }

--- a/logic/message.py
+++ b/logic/message.py
@@ -263,7 +263,7 @@ def messages_data_handler(user_data, user_data_lock, user_data_copied, ui_queue,
             return
 
 
-        # and immediately save the new pads and replay protection number
+        # and immediately save the new pads and the hash chain
         with user_data_lock:
             user_data["contacts"][contact_id]["contact_pads"]["pads"]       = contact_pads
             user_data["contacts"][contact_id]["contact_pads"]["hash_chain"] = next_hash_chain

--- a/logic/pfs.py
+++ b/logic/pfs.py
@@ -26,14 +26,14 @@ def send_new_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue) -> 
     lt_sign_private_key = user_data_copied["contacts"][contact_id]["lt_sign_keys"]["our_keys"]["private_key"]
     
     # Check if we already have a hash chain for ourselves
-    if not user_data_copied["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"]:
+    if not user_data_copied["contacts"][contact_id]["lt_sign_keys"]["our_hash_chain"]:
         with user_data_lock:
             # Set up the hash chain's initial seed
-            user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] = secrets.token_bytes(64)
+            user_data["contacts"][contact_id]["lt_sign_keys"]["our_hash_chain"] = secrets.token_bytes(64)
             
-            our_hash_chain = user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] 
+            our_hash_chain = user_data["contacts"][contact_id]["lt_sign_keys"]["our_hash_chain"] 
     else:
-        our_hash_chain = user_data_copied["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] 
+        our_hash_chain = user_data_copied["contacts"][contact_id]["lt_sign_keys"]["our_hash_chain"] 
         # We continue the hash chain
         our_hash_chain = sha3_512(our_hash_chain)
 
@@ -67,7 +67,7 @@ def send_new_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue) -> 
         # user_data["contacts"][contact_id]["ephemeral_keys"]["contact_public_key"]      = None
 
 
-        user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] = our_hash_chain
+        user_data["contacts"][contact_id]["lt_sign_keys"]["our_hash_chain"] = our_hash_chain
 
         # Set rotation counters to rotate every 2 pad batches sent
         # TODO: Maybe rotate on every batch instead? and rework the counters, like we don't even need counters if we rotate on every batch sent.
@@ -114,12 +114,12 @@ def pfs_data_handler(user_data, user_data_lock, user_data_copied, ui_queue, mess
     contact_hash_chain       = contact_kyber_publickey_hashchain[:64]
 
     # If we do not have a hashchain for the contact, we don't need to compute the chain, just save.
-    if not user_data_copied["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"]:
+    if not user_data_copied["contacts"][contact_id]["lt_sign_keys"]["contact_hash_chain"]:
         with user_data_lock:
-            user_data["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"] = contact_hash_chain
+            user_data["contacts"][contact_id]["lt_sign_keys"]["contact_hash_chain"] = contact_hash_chain
     
     else:
-        contact_last_hash_chain = user_data_copied["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"]
+        contact_last_hash_chain = user_data_copied["contacts"][contact_id]["lt_sign_keys"]["contact_hash_chain"]
         contact_last_hash_chain = sha3_512(contact_last_hash_chain)
 
         if contact_last_hash_chain != contact_hash_chain:
@@ -127,7 +127,7 @@ def pfs_data_handler(user_data, user_data_lock, user_data_copied, ui_queue, mess
             return
 
     with user_data_lock:
-        user_data["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"] = contact_hash_chain
+        user_data["contacts"][contact_id]["lt_sign_keys"]["contact_hash_chain"] = contact_hash_chain
         user_data["contacts"][contact_id]["ephemeral_keys"]["contact_public_key"] = contact_kyber_public_key
 
 

--- a/logic/pfs.py
+++ b/logic/pfs.py
@@ -1,6 +1,5 @@
 from core.requests import http_request
 from logic.storage import save_account_data
-from logic.get_user import get_target_lt_public_key
 from core.crypto import generate_kem_keys, verify_signature, create_signature, generate_sign_keys, random_number_range
 from core.trad_crypto import derive_key_argon2id, sha3_512
 from base64 import b64encode, b64decode
@@ -15,90 +14,16 @@ import oqs
 
 logger = logging.getLogger(__name__)
 
-def rotate_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue) -> None:
-    with user_data_lock:
-        user_data_copied = copy.deepcopy(user_data)
-  
-    server_url = user_data_copied["server_url"]
-    auth_token = user_data_copied["token"]
 
-    d5_private_key = user_data_copied["contacts"][contact_id]["message_sign_keys"]["our_keys"]["private_key"]
-
-
-    # Check if we already have a hash chain for ourselves
-    if not user_data_copied["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"]:
-        with user_data_lock:
-            # Set up the hash chain's initial seed
-            user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] = secrets.token_bytes(64)
-            
-            our_hash_chain = user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] 
-    else:
-        our_hash_chain = user_data_copied["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] 
-        # We continue the hash chain
-        our_hash_chain = sha3_512(our_hash_chain)
-
-
-    # Generate new Kyber1024 keys for us and send them to contact
-    kyber_private_key, kyber_public_key = generate_kem_keys()
-
-    # Sign them with our per-contact long-term private key
-    kyber_key_hashchain_signature = create_signature("Dilithium5", our_hash_chain + kyber_public_key, d5_private_key)
-    
-    payload = {
-            "kyber_publickey_hashchain": b64encode(our_hash_chain + kyber_public_key).decode(),
-            "kyber_hashchain_signature": b64encode(kyber_key_hashchain_signature).decode(),
-            "recipient"                : contact_id,
-            "pfs_type"                 : "rotate"
-        }
-
-
-    try:
-        response = http_request(f"{server_url}/pfs/send_keys", "POST", payload=payload, auth_token=auth_token)
-    except:
-        ui_queue.put({"type": "showerror", "title": "Error", "message": "Failed to send our rotated ephemeral keys to the server"})
-        return
-    
-
-    # We update at the very end to ensure if any of previous steps fail, we do not desync our state
-    with user_data_lock:
-        user_data["contacts"][contact_id]["ephemeral_keys"]["our_keys"]["private_key"] = kyber_private_key
-        user_data["contacts"][contact_id]["ephemeral_keys"]["our_keys"]["public_key"] = kyber_public_key
-
-        user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] = our_hash_chain
-
-        rotation_counter = user_data["contacts"][contact_id]["ephemeral_keys"]["rotation_counter"]
-        rotate_at        = user_data["contacts"][contact_id]["ephemeral_keys"]["rotate_at"]
-        if rotation_counter == rotate_at:
-            # Reset rotation counter because we rotated successfully
-            user_data["contacts"][contact_id]["ephemeral_keys"]["rotation_counter"] = 0
-            user_data["contacts"][contact_id]["ephemeral_keys"]["rotate_at"]        = 2
-
-
-
-# TODO: Some of code here is duplicated in rotate_ephemeral_keys function, maybe clean it up?
 def send_new_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue) -> None:
     with user_data_lock:
         user_data_copied = copy.deepcopy(user_data)
+
   
     server_url = user_data_copied["server_url"]
     auth_token = user_data_copied["token"]
 
-
-    lt_sign_private_key = user_data_copied["lt_auth_sign_keys"]["private_key"]
-
-    # If we haven't generated and sent a long-term per-contact dilithium5 key used for signing messages
-    if not user_data_copied["contacts"][contact_id]["message_sign_keys"]["our_keys"]["private_key"]:
-        d5_private_key, d5_public_key = generate_sign_keys()
-       
-        # These keys are fine to save now, even if the request below fails
-        with user_data_lock:
-            user_data["contacts"][contact_id]["message_sign_keys"]["our_keys"]["private_key"] = d5_private_key
-            user_data["contacts"][contact_id]["message_sign_keys"]["our_keys"]["public_key"] =  d5_public_key
-
-    else:
-        d5_private_key = user_data["contacts"][contact_id]["message_sign_keys"]["our_keys"]["private_key"]
-        d5_public_key  = user_data["contacts"][contact_id]["message_sign_keys"]["our_keys"]["public_key"]
-
+    lt_sign_private_key = user_data_copied["contacts"][contact_id]["lt_sign_keys"]["our_keys"]["private_key"]
     
     # Check if we already have a hash chain for ourselves
     if not user_data_copied["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"]:
@@ -112,31 +37,18 @@ def send_new_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue) -> 
         # We continue the hash chain
         our_hash_chain = sha3_512(our_hash_chain)
 
-    # Generate new Kyber1024 keys for us and send them to contact
+    # Generate new Kyber1024 keys for us
     kyber_private_key, kyber_public_key = generate_kem_keys()
 
-
     # Sign them with our per-contact long-term private key
-    kyber_key_hashchain_signature = create_signature("Dilithium5", our_hash_chain + kyber_public_key, d5_private_key)
+    kyber_key_hashchain_signature = create_signature("Dilithium5", our_hash_chain + kyber_public_key, lt_sign_private_key)
     
     payload = {
             "kyber_publickey_hashchain": b64encode(our_hash_chain + kyber_public_key).decode(),
             "kyber_hashchain_signature": b64encode(kyber_key_hashchain_signature).decode(),
             "recipient"                : contact_id,
-            "pfs_type"                 : "init"
         }
 
-
-    if not user_data_copied["contacts"][contact_id]["message_sign_keys"]["contact_public_key"]:
-        # We avoid sending d5 public key and signature, because if we have the contact public_key
-        # it means he has received our d5 public_key already
-        # This is important step to avoid over-using our long-term key, which might weaken its security
-        #
-        # TODO: Add replay protection here too, but just hash contact public-key and append it to start of d5_public_key
-
-        d5_key_signature = create_signature("Dilithium5", d5_public_key, lt_sign_private_key)
-        payload["d5_public_key"] = b64encode(d5_public_key).decode()
-        payload["d5_signature"] = b64encode(d5_key_signature).decode()
 
     try:
         response = http_request(f"{server_url}/pfs/send_keys", "POST", payload=payload, auth_token=auth_token)
@@ -150,6 +62,11 @@ def send_new_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue) -> 
         user_data["contacts"][contact_id]["ephemeral_keys"]["our_keys"]["private_key"] = kyber_private_key
         user_data["contacts"][contact_id]["ephemeral_keys"]["our_keys"]["public_key"] = kyber_public_key
 
+
+        # This one should prevent any pad generation and sending, until contact sends us his new ephemeral keys too
+        # user_data["contacts"][contact_id]["ephemeral_keys"]["contact_public_key"]      = None
+
+
         user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] = our_hash_chain
 
         # Set rotation counters to rotate every 2 pad batches sent
@@ -161,6 +78,9 @@ def send_new_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue) -> 
         user_data["tmp"]["ephemeral_key_send_lock"][contact_id] = True
 
 
+
+
+
 def pfs_data_handler(user_data, user_data_lock, user_data_copied, ui_queue, message) -> None:
     contact_id = message["sender"]
 
@@ -170,7 +90,8 @@ def pfs_data_handler(user_data, user_data_lock, user_data_copied, ui_queue, mess
         return
 
     # Contact's main long-term public signing key
-    contact_lt_public_key = user_data_copied["contacts"][contact_id]["lt_sign_public_key"]
+    contact_lt_public_key = user_data_copied["contacts"][contact_id]["lt_sign_keys"]["contact_public_key"]
+
 
     if not contact_lt_public_key:
         logger.error("Contact long-term signing key is missing... 0 clue how we reached here, but we aint continuing..")
@@ -180,123 +101,65 @@ def pfs_data_handler(user_data, user_data_lock, user_data_copied, ui_queue, mess
         logger.error("Contact long-term signing key is not verified! it is possible that this is a MiTM attack by the server, we ignoring this PFS for now.")
         return
 
-    if message["pfs_type"] == "rotate":
-        d5_public_key = user_data_copied["contacts"][contact_id]["message_sign_keys"]["contact_public_key"]
+    contact_kyber_hashchain_signature = b64decode(message["kyber_hashchain_signature"], validate=True)
+    contact_kyber_publickey_hashchain = b64decode(message["kyber_publickey_hashchain"], validate=True)
 
-        contact_kyber_hashchain_signature = b64decode(message["kyber_hashchain_signature"], validate=True)
-        contact_kyber_publickey_hashchain = b64decode(message["kyber_publickey_hashchain"], validate=True)
-
-        valid_signature = verify_signature("Dilithium5", contact_kyber_publickey_hashchain, contact_kyber_hashchain_signature, d5_public_key)
-        if not valid_signature:
-            logger.error("Invalid ephemeral kyber public-key + hashchain signature! possible MiTM ?")
-            return
+    valid_signature = verify_signature("Dilithium5", contact_kyber_publickey_hashchain, contact_kyber_hashchain_signature, contact_lt_public_key)
+    if not valid_signature:
+        logger.error("Invalid ephemeral kyber public-key + hashchain signature! possible MiTM ?")
+        return
 
 
-        contact_kyber_public_key = contact_kyber_publickey_hashchain[64:]
-        contact_hash_chain       = contact_kyber_publickey_hashchain[:64]
-        contact_last_hash_chain  = user_data_copied["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"]
-        if not contact_last_hash_chain:
-            logger.error("Contact does not have a saved hash chain despite asking to rotate ephemeral keys! You may have discovered a bug.")
-            return
-        else:
-            contact_last_hash_chain = sha3_512(contact_last_hash_chain)
+    contact_kyber_public_key = contact_kyber_publickey_hashchain[64:]
+    contact_hash_chain       = contact_kyber_publickey_hashchain[:64]
 
-            if contact_last_hash_chain != contact_hash_chain:
-                logger.error("Contact hash chain does not match our computed hash chain, we are skipping this PFS message...")
-                return
-
+    # If we do not have a hashchain for the contact, we don't need to compute the chain, just save.
+    if not user_data_copied["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"]:
         with user_data_lock:
             user_data["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"] = contact_hash_chain
-            user_data["contacts"][contact_id]["ephemeral_keys"]["contact_public_key"] = contact_kyber_public_key
-
-        logger.info("Contact (%s) has rotated his ephemeral kyber keys")
-
-    elif message["pfs_type"] == "init":
-        if (not user_data_copied["contacts"][contact_id]["message_sign_keys"]["contact_public_key"]) and ((not ("d5_public_key" in message)) or not ("d5_signature" in message)):
-            logger.error("Contact did not send the per-contact Dilithium5 public key or its signature despite us not having a copy... skipping PFS message")
-            return
-
-        # Check if contact wants to send or rotate long-term per-contact signing keys
-        if ("d5_public_key" in message) and ("d5_signature" in message):
-            d5_public_key = b64decode(message["d5_public_key"], validate=True)
-            d5_signature  = b64decode(message["d5_signature"], validate=True)
-            valid_signature = verify_signature("Dilithium5", d5_public_key, d5_signature, contact_lt_public_key)
-            if not valid_signature:
-                logger.error("Invalid per-contact Dilithium5 public-key signature! possible MiTM ?")
-                return
-
-            # This is so it allows multiple key rotation within the same session without restarting the app
-            with user_data_lock:
-                if contact_id in user_data["tmp"]["ephemeral_key_send_lock"]:
-                    del user_data["tmp"]["ephemeral_key_send_lock"][contact_id]
-
-        else:
-            d5_public_key = user_data_copied["contacts"][contact_id]["message_sign_keys"]["contact_public_key"]
-
-        contact_kyber_hashchain_signature = b64decode(message["kyber_hashchain_signature"], validate=True)
-        contact_kyber_publickey_hashchain = b64decode(message["kyber_publickey_hashchain"], validate=True)
-
-        valid_signature = verify_signature("Dilithium5", contact_kyber_publickey_hashchain, contact_kyber_hashchain_signature, d5_public_key)
-        if not valid_signature:
-            logger.error("Invalid ephemeral kyber public-key + hashchain signature! possible MiTM ?")
-            return
-
-
-        contact_kyber_public_key = contact_kyber_publickey_hashchain[64:]
-        contact_hash_chain       = contact_kyber_publickey_hashchain[:64]
-
-        # If we do not have a hashchain for the contact, we don't need to compute the chain, just save.
-        if not user_data_copied["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"]:
-            with user_data_lock:
-                user_data["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"] = contact_hash_chain
-        
-        else:
-            contact_last_hash_chain = user_data_copied["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"]
-            contact_last_hash_chain = sha3_512(contact_last_hash_chain)
-
-            if contact_last_hash_chain != contact_hash_chain:
-                logger.error("Contact hash chain does not match our computed hash chain, we are skipping this PFS message...")
-                return
-
-        with user_data_lock:
-            user_data["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"] = contact_hash_chain
-            user_data["contacts"][contact_id]["ephemeral_keys"]["contact_public_key"] = contact_kyber_public_key
-
-
-        # TODO: Investigate possible infinite loopback
-        # Details: What if contact_id wasn't in tmp (i.e. user closed the app and re-opened later )
-        # then we re-send the keys ?! And not only that, if the contact also offline, and he receive it
-        # he will also resend keys
-        # and if we are offline, we also resend keys.
-        # so on and so fourth
-        # Maybe ephemeral_key_send_lock need to be in the contact info, not in tmp ?
-
-        if contact_id in user_data_copied["tmp"]["ephemeral_key_send_lock"]:
-            logger.debug("We don't have to re-send keys, as we already have sent them, time to inform user of success :)")
-
-            # Incase this was auto-fired by SMP's step 4, we don't want to give the user another popup
-            if not (contact_id in user_data_copied["tmp"]["pfs_do_not_inform"]):
-                logger.info("Successfully initialized ephemeral keys with contacts (%s)", contact_id)
-                ui_queue.put({"type": "showinfo", "title": "Success", "message": f"Successfully initialized ephemeral keys with contact ({contact_id[:32]})"})
-            else:
-                logger.info("Not informing the user of successful ephemeral keys initialization because step was likely automatically fired")
-                
-                # We delete incase user end up rotating per-contact long-term keys within the same session
-                with user_data_lock:
-                    del user_data["tmp"]["pfs_do_not_inform"][contact_id]
-        else:
-            # Send our ephemeral keys back to the contact
-            send_new_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue)
-
-        with user_data_lock:
-            user_data["contacts"][contact_id]["message_sign_keys"]["contact_public_key"] = d5_public_key
-
-            if contact_id in user_data["tmp"]["ephemeral_key_send_lock"]:
-                del user_data["tmp"]["ephemeral_key_send_lock"][contact_id]
     
     else:
-        logger.error("Received PFS message with unknown type (%s), skipping it...", message["pfs_type"])
-        return
+        contact_last_hash_chain = user_data_copied["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"]
+        contact_last_hash_chain = sha3_512(contact_last_hash_chain)
+
+        if contact_last_hash_chain != contact_hash_chain:
+            logger.error("Contact hash chain does not match our computed hash chain, we are skipping this PFS message...")
+            return
+
+    with user_data_lock:
+        user_data["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"] = contact_hash_chain
+        user_data["contacts"][contact_id]["ephemeral_keys"]["contact_public_key"] = contact_kyber_public_key
+
+
+    # TODO: Investigate possible infinite loopback
+    # Details: What if contact_id wasn't in tmp (i.e. user closed the app and re-opened later )
+    # then we re-send the keys ?! And not only that, if the contact also offline, and he receive it
+    # he will also resend keys
+    # and if we are offline, we also resend keys.
+    # so on and so fourth
+    # Maybe ephemeral_key_send_lock need to be in the contact info, not in tmp ?
+
+    if contact_id in user_data_copied["tmp"]["ephemeral_key_send_lock"]:
+        logger.debug("We don't have to re-send keys, as we already have sent them, time to inform user of success :)")
+
+        # Incase this was auto-fired by SMP's step 4, we don't want to give the user another popup
+        if not (contact_id in user_data_copied["tmp"]["pfs_do_not_inform"]):
+            logger.info("Successfully initialized ephemeral keys with contacts (%s)", contact_id)
+            ui_queue.put({"type": "showinfo", "title": "Success", "message": f"Successfully initialized ephemeral keys with contact ({contact_id[:32]})"})
+        else:
+            logger.info("Not informing the user of successful ephemeral keys initialization because step was likely automatically fired")
+            
+            # We delete incase user end up rotating per-contact long-term keys within the same session
+            with user_data_lock:
+                del user_data["tmp"]["pfs_do_not_inform"][contact_id]
+    else:
+        # Send our ephemeral keys back to the contact
+        send_new_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue)
+
+    with user_data_lock:
+        if contact_id in user_data["tmp"]["ephemeral_key_send_lock"]:
+            del user_data["tmp"]["ephemeral_key_send_lock"][contact_id]
+
 
     save_account_data(user_data, user_data_lock)
 

--- a/logic/smp.py
+++ b/logic/smp.py
@@ -280,7 +280,6 @@ def smp_step_4(user_data, user_data_lock, contact_id, message, ui_queue) -> None
     # the contact as unverified despite verifiying him ?
     #
     
-    # 
     send_new_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue)
 
 

--- a/logic/smp.py
+++ b/logic/smp.py
@@ -33,9 +33,8 @@
 from core.requests import http_request
 from logic.storage import save_account_data
 from logic.contacts import save_contact
-from logic.get_user import get_target_lt_public_key
 from logic.pfs import send_new_ephemeral_keys
-from core.crypto import random_number_range
+from core.crypto import random_number_range, generate_sign_keys
 from core.trad_crypto import derive_key_argon2id, sha3_512
 from base64 import b64encode, b64decode
 import hashlib
@@ -62,10 +61,13 @@ def initiate_smp(user_data: dict, user_data_lock, contact_id: str, question: str
     
     our_nonce = b64encode(secrets.token_bytes(32)).decode()
 
+    private_key, public_key = generate_sign_keys()
+
     try:
         response = http_request(f"{server_url}/smp/initiate", "POST", payload = {
             "question": question,
             "nonce": our_nonce,
+            "public_key": b64encode(public_key).decode(),
             "recipient": contact_id
 
         }, auth_token=auth_token)
@@ -86,25 +88,32 @@ def initiate_smp(user_data: dict, user_data_lock, contact_id: str, question: str
         user_data["contacts"][contact_id]["lt_sign_key_smp"]["our_nonce"]            = our_nonce
         user_data["contacts"][contact_id]["lt_sign_key_smp"]["smp_step"]             = 1
 
+        user_data["contacts"][contact_id]["lt_sign_keys"]["our_keys"]["private_key"] = private_key
+        user_data["contacts"][contact_id]["lt_sign_keys"]["our_keys"]["public_key"] = public_key
+
 
 
     logger.debug("Initiated SMP for %s", contact_id)
     save_account_data(user_data, user_data_lock)
 
 
-def smp_step_2_answer_provided(user_data, user_data_lock, contact_id, answer) -> None:
+def smp_step_2_answer_provided(user_data, user_data_lock, contact_id, answer, ui_queue) -> None:
     answer = normalize_answer(answer)
 
     our_nonce = secrets.token_bytes(32)
+
+    private_key, public_key = generate_sign_keys()
+    
     with user_data_lock:
         server_url = user_data["server_url"]
         auth_token = user_data["token"]
 
         # We already check on server that base64 of nonce is valid, and if the server wants to crash us, it can through other ways :)
         contact_nonce      = b64decode(user_data["contacts"][contact_id]["lt_sign_key_smp"]["contact_nonce"], validate=True)
-        contact_public_key = user_data["contacts"][contact_id]["lt_sign_public_key"]
+        
+        contact_public_key = user_data["contacts"][contact_id]["lt_sign_keys"]["contact_public_key"]
 
-            # We use SHA3-512, because SHA3's Keccak sponge remains indifferentitable from a random oracle even under quantum attacks
+    # We use SHA3-512, because SHA3's Keccak sponge remains indifferentitable from a random oracle even under quantum attacks
     contact_key_fingerprint = sha3_512(contact_public_key)
 
     # Derieve a high-entropy secret key from the low-entropy answer 
@@ -117,10 +126,12 @@ def smp_step_2_answer_provided(user_data, user_data_lock, contact_id, answer) ->
 
     logger.debug("Our message: %s", our_message)
 
+    
     try:
         response = http_request(f"{server_url}/smp/step_2", "POST", payload = {
             "proof": our_message,
             "nonce": b64encode(our_nonce).decode(),
+            "public_key": b64encode(public_key).decode(),
             "recipient": contact_id
 
         }, auth_token=auth_token)
@@ -135,12 +146,15 @@ def smp_step_2_answer_provided(user_data, user_data_lock, contact_id, answer) ->
         user_data["contacts"][contact_id]["lt_sign_key_smp"]["our_nonce"] = b64encode(our_nonce).decode()
         user_data["contacts"][contact_id]["lt_sign_key_smp"]["answer"] = answer
 
-
+        user_data["contacts"][contact_id]["lt_sign_keys"]["our_keys"]["private_key"] = private_key
+        user_data["contacts"][contact_id]["lt_sign_keys"]["our_keys"]["public_key"] = public_key
 
 
 
 def smp_step_2_request_answer(user_data, user_data_lock, contact_id, message, ui_queue) -> None:
     with user_data_lock:
+        user_data["contacts"][contact_id]["lt_sign_keys"]["contact_public_key"]      = b64decode(message["public_key"], validate=True)
+        
         user_data["contacts"][contact_id]["lt_sign_key_smp"]["pending_verification"] = True
         user_data["contacts"][contact_id]["lt_sign_key_smp"]["question"]             = message["question"]
         user_data["contacts"][contact_id]["lt_sign_key_smp"]["contact_nonce"]        = message["nonce"]
@@ -159,10 +173,14 @@ def smp_step_3(user_data, user_data_lock, contact_id, message, ui_queue) -> None
         server_url = user_data["server_url"]
         auth_token = user_data["token"]
 
-        answer = normalize_answer(user_data["contacts"][contact_id]["lt_sign_key_smp"]["answer"])
-        our_public_key = user_data["lt_auth_sign_keys"]["public_key"]
-        our_nonce = b64decode(user_data["contacts"][contact_id]["lt_sign_key_smp"]["our_nonce"], validate=True)
-        contact_public_key = user_data["contacts"][contact_id]["lt_sign_public_key"]
+        answer         = normalize_answer(user_data["contacts"][contact_id]["lt_sign_key_smp"]["answer"])
+
+        our_public_key = user_data["contacts"][contact_id]["lt_sign_keys"]["our_keys"]["public_key"]
+        our_nonce      = b64decode(user_data["contacts"][contact_id]["lt_sign_key_smp"]["our_nonce"], validate=True)
+
+        contact_public_key = b64decode(message["public_key"], validate=True)
+
+        user_data["contacts"][contact_id]["lt_sign_keys"]["contact_public_key"] = b64decode(message["public_key"], validate=True)
 
     
     contact_nonce = b64decode(message["nonce"], validate=True)
@@ -219,11 +237,11 @@ def smp_step_4(user_data, user_data_lock, contact_id, message, ui_queue) -> None
 
         answer = normalize_answer(user_data["contacts"][contact_id]["lt_sign_key_smp"]["answer"])
 
-        our_public_key     = user_data["lt_auth_sign_keys"]["public_key"]
+        our_public_key     = user_data["contacts"][contact_id]["lt_sign_keys"]["our_keys"]["public_key"]
         our_nonce          = b64decode(user_data["contacts"][contact_id]["lt_sign_key_smp"]["our_nonce"], validate=True)
         contact_nonce      = b64decode(user_data["contacts"][contact_id]["lt_sign_key_smp"]["contact_nonce"], validate=True)
-        contact_public_key = user_data["contacts"][contact_id]["lt_sign_public_key"]
 
+        contact_public_key = user_data["contacts"][contact_id]["lt_sign_keys"]["contact_public_key"]
     
     our_key_fingerprint = sha3_512(our_public_key)
 
@@ -261,6 +279,8 @@ def smp_step_4(user_data, user_data_lock, contact_id, message, ui_queue) -> None
     # NOTE: Maybe we need a delay here to ensure if a failure occured in contact's step 3, we catch it and mark 
     # the contact as unverified despite verifiying him ?
     #
+    
+    # 
     send_new_ephemeral_keys(user_data, user_data_lock, contact_id, ui_queue)
 
 
@@ -343,11 +363,9 @@ def smp_data_handler(user_data, user_data_lock, user_data_copied, ui_queue, mess
 
         logger.info("We received a new SMP request for a contact we did not have saved")
 
-        # Get that public _key
-        contact_public_key = get_target_lt_public_key(user_data_copied, contact_id)
 
         # Save them in-memory
-        save_contact(user_data, user_data_lock, contact_id, contact_public_key)
+        save_contact(user_data, user_data_lock, contact_id)
 
         # Perform the next SMP step
         smp_step_2_request_answer(user_data, user_data_lock, contact_id, message, ui_queue)

--- a/logic/storage.py
+++ b/logic/storage.py
@@ -69,24 +69,25 @@ def load_account_data(password = None) -> dict:
 
         try:
             user_data["contacts"][contact_id]["our_pads"]["pads"] = b64decode(user_data["contacts"][contact_id]["our_pads"]["pads"], validate=True)
+            user_data["contacts"][contact_id]["our_pads"]["hash_chain"] = b64decode(user_data["contacts"][contact_id]["our_pads"]["hash_chain"], validate=True)
         except TypeError:
             pass
 
         try:
             user_data["contacts"][contact_id]["contact_pads"]["pads"] = b64decode(user_data["contacts"][contact_id]["contact_pads"]["pads"], validate=True)
+            user_data["contacts"][contact_id]["contact_pads"]["hash_chain"] = b64decode(user_data["contacts"][contact_id]["contact_pads"]["hash_chain"], validate=True)
         except TypeError:
             pass
 
         try:
-            user_data["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"] = b64decode(user_data["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"], validate=True)
+            user_data["contacts"][contact_id]["lt_sign_keys"]["contact_hash_chain"] = b64decode(user_data["contacts"][contact_id]["lt_sign_keys"]["contact_hash_chain"], validate=True)
         except TypeError:
             pass
 
         try:
-            user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] = b64decode(user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"], validate=True)
+            user_data["contacts"][contact_id]["lt_sign_keys"]["our_hash_chain"] = b64decode(user_data["contacts"][contact_id]["lt_sign_keys"]["our_hash_chain"], validate=True)
         except TypeError:
             pass
-
 
 
     logger.debug("Loaded user_data from file (%s)", ACCOUNT_FILE_PATH)
@@ -134,24 +135,25 @@ def save_account_data(user_data: dict, user_data_lock, password = None) -> None:
 
         try:
             user_data["contacts"][contact_id]["our_pads"]["pads"] = b64encode(user_data["contacts"][contact_id]["our_pads"]["pads"]).decode()
+            user_data["contacts"][contact_id]["our_pads"]["hash_chain"] = b64encode(user_data["contacts"][contact_id]["our_pads"]["hash_chain"]).decode()
         except TypeError:
             pass
 
         try:
             user_data["contacts"][contact_id]["contact_pads"]["pads"] = b64encode(user_data["contacts"][contact_id]["contact_pads"]["pads"]).decode()
+            user_data["contacts"][contact_id]["contact_pads"]["hash_chain"] = b64encode(user_data["contacts"][contact_id]["contact_pads"]["hash_chain"]).decode()
         except TypeError:
             pass
 
         try:
-            user_data["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"] = b64encode(user_data["contacts"][contact_id]["ephemeral_keys"]["contact_hash_chain"]).decode()
+            user_data["contacts"][contact_id]["lt_sign_keys"]["contact_hash_chain"] = b64encode(user_data["contacts"][contact_id]["lt_sign_keys"]["contact_hash_chain"]).decode()
         except TypeError:
             pass
 
         try:
-            user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"] = b64encode(user_data["contacts"][contact_id]["ephemeral_keys"]["our_hash_chain"]).decode()
+            user_data["contacts"][contact_id]["lt_sign_keys"]["our_hash_chain"] = b64encode(user_data["contacts"][contact_id]["lt_sign_keys"]["our_hash_chain"]).decode()
         except TypeError:
             pass
-
 
 
 

--- a/logic/storage.py
+++ b/logic/storage.py
@@ -44,9 +44,6 @@ def load_account_data(password = None) -> dict:
     user_data["lt_auth_sign_keys"]["public_key"]  = b64decode(user_data["lt_auth_sign_keys"]["public_key"], validate=True)
 
     for contact_id in user_data["contacts"]:
-        user_data["contacts"][contact_id]["lt_sign_public_key"] = b64decode(user_data["contacts"][contact_id]["lt_sign_public_key"], validate=True)
-        
-
         # They probably haven't exchanged yet, so it's fine to skip decoding them 
         try:
             user_data["contacts"][contact_id]["ephemeral_keys"]["contact_public_key"] = b64decode(user_data["contacts"][contact_id]["ephemeral_keys"]["contact_public_key"], validate=True)
@@ -60,13 +57,13 @@ def load_account_data(password = None) -> dict:
             pass
 
         try:
-            user_data["contacts"][contact_id]["message_sign_keys"]["contact_public_key"] = b64decode(user_data["contacts"][contact_id]["message_sign_keys"]["contact_public_key"], validate=True)
+            user_data["contacts"][contact_id]["lt_sign_keys"]["contact_public_key"] = b64decode(user_data["contacts"][contact_id]["lt_sign_keys"]["contact_public_key"], validate=True)
         except TypeError:
             pass
         
         try:
-            user_data["contacts"][contact_id]["message_sign_keys"]["our_keys"]["private_key"] = b64decode(user_data["contacts"][contact_id]["message_sign_keys"]["our_keys"]["private_key"], validate=True)
-            user_data["contacts"][contact_id]["message_sign_keys"]["our_keys"]["public_key"] = b64decode(user_data["contacts"][contact_id]["message_sign_keys"]["our_keys"]["public_key"], validate=True)
+            user_data["contacts"][contact_id]["lt_sign_keys"]["our_keys"]["private_key"] = b64decode(user_data["contacts"][contact_id]["lt_sign_keys"]["our_keys"]["private_key"], validate=True)
+            user_data["contacts"][contact_id]["lt_sign_keys"]["our_keys"]["public_key"] = b64decode(user_data["contacts"][contact_id]["lt_sign_keys"]["our_keys"]["public_key"], validate=True)
         except TypeError:
             pass
 
@@ -111,8 +108,6 @@ def save_account_data(user_data: dict, user_data_lock, password = None) -> None:
     user_data["lt_auth_sign_keys"]["public_key"]  = b64encode(user_data["lt_auth_sign_keys"]["public_key"]).decode()
 
     for contact_id in user_data["contacts"]:
-        user_data["contacts"][contact_id]["lt_sign_public_key"] = b64encode(user_data["contacts"][contact_id]["lt_sign_public_key"]).decode()
-        
         # They probably haven't exchanged yet, so it's fine to skip decoding them 
         try:
             user_data["contacts"][contact_id]["ephemeral_keys"]["contact_public_key"] = b64encode(user_data["contacts"][contact_id]["ephemeral_keys"]["contact_public_key"]).decode()
@@ -127,13 +122,13 @@ def save_account_data(user_data: dict, user_data_lock, password = None) -> None:
 
         
         try:
-            user_data["contacts"][contact_id]["message_sign_keys"]["contact_public_key"] = b64encode(user_data["contacts"][contact_id]["message_sign_keys"]["contact_public_key"]).decode()
+            user_data["contacts"][contact_id]["lt_sign_keys"]["contact_public_key"] = b64encode(user_data["contacts"][contact_id]["lt_sign_keys"]["contact_public_key"]).decode()
         except TypeError:
             pass
         
         try:
-            user_data["contacts"][contact_id]["message_sign_keys"]["our_keys"]["private_key"] = b64encode(user_data["contacts"][contact_id]["message_sign_keys"]["our_keys"]["private_key"]).decode()
-            user_data["contacts"][contact_id]["message_sign_keys"]["our_keys"]["public_key"] = b64encode(user_data["contacts"][contact_id]["message_sign_keys"]["our_keys"]["public_key"]).decode()
+            user_data["contacts"][contact_id]["lt_sign_keys"]["our_keys"]["private_key"] = b64encode(user_data["contacts"][contact_id]["lt_sign_keys"]["our_keys"]["private_key"]).decode()
+            user_data["contacts"][contact_id]["lt_sign_keys"]["our_keys"]["public_key"] = b64encode(user_data["contacts"][contact_id]["lt_sign_keys"]["our_keys"]["public_key"]).decode()
         except TypeError:
             pass
 

--- a/ui/add_contact_prompt.py
+++ b/ui/add_contact_prompt.py
@@ -1,6 +1,6 @@
 from tkinter import messagebox
 from ui.utils import *
-from logic.get_user import get_target_lt_public_key
+from logic.get_user import check_if_contact_exists
 from logic.contacts import save_contact
 from logic.storage import save_account_data
 import tkinter as tk
@@ -51,8 +51,11 @@ class AddContactPrompt(tk.Toplevel):
             return
             
         try:
-            contact_public_key = get_target_lt_public_key(self.master.user_data, contact_id)
-            save_contact(self.master.user_data, self.master.user_data_lock, contact_id, contact_public_key)
+            if not check_if_contact_exists(self.master.user_data, self.master.user_data_lock, contact_id):
+                logger.info("[BUG] This should never execute, because the server should return a 40X error code and that should cause an exception..")
+                return
+
+            save_contact(self.master.user_data, self.master.user_data_lock, contact_id)
             save_account_data(self.master.user_data, self.master.user_data_lock)
         except ValueError as e:
             self.status.config(text=e, fg="red")

--- a/ui/smp_question_window.py
+++ b/ui/smp_question_window.py
@@ -51,6 +51,6 @@ class SMPQuestionWindow(tk.Toplevel):
             messagebox.showerror("Error", "You need to provide an answer.")
             return
 
-        smp_step_2_answer_provided(self.master.user_data, self.master.user_data_lock, self.contact_id, answer)
+        smp_step_2_answer_provided(self.master.user_data, self.master.user_data_lock, self.contact_id, answer, self.master.ui_queue)
 
         self.destroy()


### PR DESCRIPTION
This adds true plausible deniability to messages, messages aren't cryptographically tied to your identity key
Additionally, I've simplified a lot of perfect-forward-secrecy logic, removed a lot of unnecessary functions and lines of code.

And now messages don't have a replay_protection_number, instead we use a hash chain, which shouldn't reveal how many messages were sent in the chat.

And some misc fixes here and there 